### PR TITLE
Handle datatype changes in forthcoming Galaxy release.

### DIFF
--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Dataset.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Dataset.java
@@ -10,7 +10,8 @@ import com.github.jmchilton.blend4j.galaxy.beans.collection.response.ElementResp
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class Dataset extends HistoryContents implements HasGalaxyUrl, ElementResponse {
-  private String dataType;
+  private String dataType = null;
+  private String fileExt = null;
   private String downloadUrl;
   private Integer fileSize;
   private String genomeBuild;
@@ -47,13 +48,44 @@ public class Dataset extends HistoryContents implements HasGalaxyUrl, ElementRes
     this.visible = visible;
   }
 
+  /**
+ * @deprecated  As of 1.2 release, replaced by {@link #getDataTypeExt()}.
+ */
+  @Deprecated
   public String getDataType() {
+    return getDataTypeExt();
+  }
+
+  public String getDataTypeExt() {
+    // Hacked up due to backard incompatible changes made to the
+    // Galaxy API as of the October 2014 release of Galaxy.
+    // https://bitbucket.org/galaxy/galaxy-central/commits/9d152ed
+    if(this.fileExt != null) {
+      return this.fileExt;
+    } else {
+      return dataType;
+    }
+  }
+
+  /**
+   * This returns the Python module and class of the data type corresponding
+   * to this object. (Starting from the October 2014 version of Galaxy.)
+   *
+   */
+  public String getDataTypeClass() {
     return dataType;
   }
 
   @JsonProperty("data_type")
   public void setDataType(String dataType) {
+    // Meanaing of this property changed with October 2014 release (see note
+    // above).
     this.dataType = dataType;
+  }
+
+  @JsonProperty("file_ext")
+  public void setFileExt(final String fileExt) {
+    this.fileExt = fileExt;
   }
 
   public String getDownloadUrl() {

--- a/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
+++ b/src/test/java/com/github/jmchilton/blend4j/galaxy/HistoriesTest.java
@@ -1,21 +1,20 @@
 package com.github.jmchilton.blend4j.galaxy;
 
+import com.github.jmchilton.blend4j.galaxy.beans.Dataset;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContents;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryContentsProvenance;
 import com.github.jmchilton.blend4j.galaxy.beans.HistoryExport;
 import com.github.jmchilton.blend4j.galaxy.beans.OutputDataset;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.request.AbstractElement;
-import com.github.jmchilton.blend4j.galaxy.beans.collection.request.CollectionElement;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.request.CollectionDescription;
+import com.github.jmchilton.blend4j.galaxy.beans.collection.request.CollectionElement;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.request.HistoryDatasetElement;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.response.CollectionElementResponse;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.response.CollectionResponse;
 import com.github.jmchilton.blend4j.galaxy.beans.collection.response.ElementResponse;
 import com.sun.jersey.api.client.ClientResponse;
-
 import java.io.File;
 import java.util.List;
-
 import org.junit.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -358,13 +357,30 @@ public class HistoriesTest {
   @Test
   public void testProvenance() {
     final String historyId = TestHelpers.getTestHistoryId(instance);
+    final HistoryContents contents = getTestHistoryDataset(historyId);
+    final HistoryContentsProvenance prov = historiesClient.showProvenance(historyId, contents.getId());
+    // TODO: Test some stuff about prov - for now it is verifying serialization
+    // etc... though.
+  }
+
+  @Test
+  public void testShowDataset() throws InterruptedException {
+    final String historyId = TestHelpers.getTestHistoryId(instance);
+    final HistoryContents contents = getTestHistoryDataset(historyId);
+    final Dataset dataset = historiesClient.showDataset(historyId, contents.getId());
+    assert dataset.getDataType().equals("txt") : dataset.getDataType();
+    assert dataset.getDataTypeExt().equals("txt") : dataset.getDataTypeExt();
+  }
+
+  private HistoryContents getTestHistoryDataset(final String historyId) throws InterruptedException {
     final File testFile = TestHelpers.getTestFile();
     final ToolsClient.FileUploadRequest request = new ToolsClient.FileUploadRequest(historyId, testFile);
     final ClientResponse clientResponse = toolsClient.uploadRequest(request);
     
     final List<HistoryContents> contentsList = historiesClient.showHistoryContents(historyId);
     final HistoryContents contents = contentsList.get(0);
-    final HistoryContentsProvenance prov = historiesClient.showProvenance(historyId, contents.getId());    
+    TestHelpers.waitForHistory(historiesClient, historyId);
+    return contents;
   }
   
 }


### PR DESCRIPTION
The forthcoming release of Galaxy makes breaking change to history contents API - data_type will no longer represent the short format/file extension of the history dataset - it will now represent the Python module and class.

This commit modifies getDataType() to work the same either way - but since for the newer version it isn't literally returning 'data_type' attribute - I have deprecated this method. The new method getDataTypeExt() should be used instead.

This commit also adds getDataTypeClass() that always returns this 'data_type' attribute (but the actual method name only makes sense when taretting a newer verion of Galaxy).

For more information on the Galaxy API changes see https://bitbucket.org/galaxy/galaxy-central/commits/9d152ed#chg-lib/galaxy/model/__init__.py.
