### PR TITLE
Update galaxy-bootstrap dependency to 0.4.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.github.jmchilton.galaxybootstrap</groupId>
       <artifactId>galaxybootstrap</artifactId>
-      <version>0.4.0</version>
+      <version>0.4.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
It has a fix for the upcoming release of Galaxy.
