### PR TITLE
Registers MultiPartWriter.class with the ClientConfig before creating…

### DIFF
--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/DefaultWebResourceFactoryImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/DefaultWebResourceFactoryImpl.java
@@ -5,6 +5,7 @@ import com.sun.jersey.api.client.config.ClientConfig;
 import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.api.client.filter.LoggingFilter;
 import com.sun.jersey.api.json.JSONConfiguration;
+import com.sun.jersey.multipart.impl.MultiPartWriter;
 
 /**
  * Default and simplest possible implementation of WebResourceFactory.
@@ -66,6 +67,7 @@ public class DefaultWebResourceFactoryImpl implements WebResourceFactory {
    */
   protected com.sun.jersey.api.client.Client getJerseyClient() {
     final ClientConfig clientConfig = new DefaultClientConfig();
+    clientConfig.getClasses().add(MultiPartWriter.class);
     clientConfig.getFeatures().put(JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE);
     com.sun.jersey.api.client.Client client = com.sun.jersey.api.client.Client.create(clientConfig);
     if(this.debug) {


### PR DESCRIPTION
I am attempting to use Blend4J to manipulate Galaxy programmatically.  In particular to  use the ToolsClient.uploadRequest method to add a file to the current history in Galaxy.  However, at runtime this results in the exception:

```
com.sun.jersey.api.client.ClientHandlerException: A message body writer for Java type, class com.sun.jersey.multipart.FormDataMultiPart, and MIME media type, multipart/form-data, was not found
```

I found this solution on StackOverflow that does solve the problem for me:
http://stackoverflow.com/questions/15585074/jersey-client-exception-a-message-body-writer-was-not-found.

Even though the MultiPartWriter class is available on the CLASSPATH it still needs to be added to the ClientConfig. This PR simply applies the above fix.
